### PR TITLE
修复宿主 APK 的 SO 文件为空导致 libsandhook.so 拷贝失败的问题。

### DIFF
--- a/xpatch/src/main/java/com/storm/wind/xpatch/task/SoAndDexCopyTask.java
+++ b/xpatch/src/main/java/com/storm/wind/xpatch/task/SoAndDexCopyTask.java
@@ -51,9 +51,11 @@ public class SoAndDexCopyTask implements Runnable {
     private void copySoFile() {
         for (String libPath : APK_LIB_PATH_ARRAY) {
             String apkSoFullPath = fullLibPath(libPath);
-            if(new File(apkSoFullPath).exists()) {
-                copyLibFile(apkSoFullPath, SO_FILE_PATH_MAP.get(libPath));
+            File apkSoFullPathFile= new File(apkSoFullPath);
+            if (!apkSoFullPathFile.exists()){
+                apkSoFullPathFile.mkdirs();
             }
+            copyLibFile(apkSoFullPath, SO_FILE_PATH_MAP.get(libPath));
         }
         // copy xposed modules into the lib path
         if (xposedModuleArray != null && xposedModuleArray.length > 0) {


### PR DESCRIPTION
修复宿主 APK 的 SO 文件为空导致 libsandhook.so 拷贝失败的问题。